### PR TITLE
[Fix] Assets not being published in 'public' file group

### DIFF
--- a/src/Providers/CmsThemeServiceProvider.php
+++ b/src/Providers/CmsThemeServiceProvider.php
@@ -24,8 +24,8 @@ class CmsThemeServiceProvider extends ServiceProvider
              ->registerMenu()
              ->loadViews()
              ->registerViewComposers()
-             ->publishAssets()
-             ->publishTranslations();
+             ->publishPublicAssets()
+             ->publishResources();
     }
 
     /**
@@ -84,12 +84,12 @@ class CmsThemeServiceProvider extends ServiceProvider
     /**
      * @return $this
      */
-    protected function publishAssets()
+    protected function publishPublicAssets()
     {
         $this->publishes([
             realpath(dirname(__DIR__)) . '/../resources/assets/build' => public_path('_cms'),
             realpath(dirname(__DIR__)) . '/../resources/assets/img'   => public_path('_cms/img'),
-        ], 'assets');
+        ], 'public');
 
         return $this;
     }
@@ -97,7 +97,7 @@ class CmsThemeServiceProvider extends ServiceProvider
     /**
      * @return $this
      */
-    protected function publishTranslations()
+    protected function publishResources()
     {
         $this->publishes([
             realpath(dirname(__DIR__)) . '/../resources/lang' => base_path('resources/lang/vendor/cms'),

--- a/src/Providers/CmsThemeServiceProvider.php
+++ b/src/Providers/CmsThemeServiceProvider.php
@@ -24,7 +24,8 @@ class CmsThemeServiceProvider extends ServiceProvider
              ->registerMenu()
              ->loadViews()
              ->registerViewComposers()
-             ->publishAssets();
+             ->publishAssets()
+             ->publishTranslations();
     }
 
     /**
@@ -88,7 +89,18 @@ class CmsThemeServiceProvider extends ServiceProvider
         $this->publishes([
             realpath(dirname(__DIR__)) . '/../resources/assets/build' => public_path('_cms'),
             realpath(dirname(__DIR__)) . '/../resources/assets/img'   => public_path('_cms/img'),
-            realpath(dirname(__DIR__)) . '/../resources/lang'         => base_path('resources/lang/vendor/cms'),
+        ], 'assets');
+
+        return $this;
+    }
+    
+    /**
+     * @return $this
+     */
+    protected function publishTranslations()
+    {
+        $this->publishes([
+            realpath(dirname(__DIR__)) . '/../resources/lang' => base_path('resources/lang/vendor/cms'),
         ], 'assets');
 
         return $this;


### PR DESCRIPTION
Aligns with https://laravel.com/docs/5.6/packages#publishing-file-groups to enable `php artisan vendor:publish --tag=public --force` to work.